### PR TITLE
Show a message if no auth URL

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -127,6 +127,8 @@
 			{@html md.render($content['site-home-logged-out'])}
 			{#if authUrl}
 				<p>👉 <a href={authUrl}>Connect my Twitter account</a></p>
+			{:else}
+				<p>😿 Server failed to initialise authentication. Contact an admin.</p>
 			{/if}
 		</section>
 	{:else if items !== undefined && !inAdminMode}

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Barney Mannerings <b.mannerings@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "~3.9"
 fastapi = "^0.68.1"
 pydantic = {extras = ["dotenv"], version = "^1.8.2"}
 tweepy = "^3.10.0"


### PR DESCRIPTION
No error on thingbox side, API access token required regeneration in production.

Adding a message for users in case this happens again.